### PR TITLE
WIP: unproject onto plane

### DIFF
--- a/src/bivec2.zig
+++ b/src/bivec2.zig
@@ -5,8 +5,9 @@ const math = std.math;
 
 const Rotor2 = geom.Rotor2;
 const Vec2 = geom.Vec2;
+const Vec3 = geom.Vec3;
 
-/// An two dimensional oriented area.
+/// A two dimensional oriented area.
 pub const Bivec2 = extern struct {
     /// The area on the yx plane, incidentally the only plane in two dimensions. The sign represents
     /// the direction.
@@ -129,6 +130,16 @@ pub const Bivec2 = extern struct {
         try testExpVsAngle(yx_plane, 2.0 * math.pi);
         try testExpVsAngle(xy_plane, -2.0 * math.pi);
         try testExpVsAngle(xy_plane, 2.0 * math.pi);
+    }
+
+    /// Returns self multiplied by yx, results in a scalar with a magnitude of the oriented area.
+    pub fn dual(self: Bivec2) f32 {
+        return -self.yx;
+    }
+
+    test dual {
+        const a: Bivec2 = .{ .yx = 2 };
+        try std.testing.expectEqual(-2, a.dual());
     }
 };
 

--- a/src/bivec4.zig
+++ b/src/bivec4.zig
@@ -1,0 +1,339 @@
+const std = @import("std");
+const geom = @import("root.zig");
+
+const math = std.math;
+
+const Vec4 = geom.Vec4;
+const Trivec4 = geom.Trivec4;
+
+/// A four dimensional oriented area.
+pub const Bivec4 = extern struct {
+    /// The area on the yz plane. The sign represents the direction.
+    yz: f32,
+    /// The area on the xz plane. The sign represents the direction.
+    xz: f32,
+    /// The area on the yx plane. The sign represents the direction.
+    yx: f32,
+    /// The area on the xw plane. The sign represents the direction.
+    xw: f32,
+    /// The area on the yw plane. The sign represents the direction.
+    yw: f32,
+    /// The area on the zw plane. The sign represents the direction.
+    zw: f32,
+
+    pub const zero: Bivec4 = .{ .yz = 0.0, .xz = 0.0, .yx = 0.0, .xw = 0, .yw = 0, .zw = 0 };
+    pub const yz_plane: Bivec4 = .{ .yz = 1.0, .xz = 0.0, .yx = 0.0, .xw = 0, .yw = 0, .zw = 0 };
+    pub const zy_plane: Bivec4 = .{ .yz = -1.0, .xz = 0.0, .yx = 0.0, .xw = 0, .yw = 0, .zw = 0 };
+    pub const xz_plane: Bivec4 = .{ .yz = 0.0, .xz = 1.0, .yx = 0.0, .xw = 0, .yw = 0, .zw = 0 };
+    pub const zx_plane: Bivec4 = .{ .yz = 0.0, .xz = -1.0, .yx = 0.0, .xw = 0, .yw = 0, .zw = 0 };
+    pub const yx_plane: Bivec4 = .{ .yz = 0.0, .xz = 0.0, .yx = 1.0, .xw = 0, .yw = 0, .zw = 0 };
+    pub const xy_plane: Bivec4 = .{ .yz = 0.0, .xz = 0.0, .yx = -1.0, .xw = 0, .yw = 0, .zw = 0 };
+
+    pub const xw_plane: Bivec4 = .{ .yz = 0.0, .xz = 0.0, .yx = 0.0, .xw = 1, .yw = 0, .zw = 0 };
+    pub const wx_plane: Bivec4 = .{ .yz = 0.0, .xz = 0.0, .yx = 0.0, .xw = -1, .yw = 0, .zw = 0 };
+    pub const yw_plane: Bivec4 = .{ .yz = 0.0, .xz = 0.0, .yx = 0.0, .xw = 0, .yw = 1, .zw = 0 };
+    pub const wy_plane: Bivec4 = .{ .yz = 0.0, .xz = 0.0, .yx = 0.0, .xw = 0, .yw = -1, .zw = 0 };
+    pub const zw_plane: Bivec4 = .{ .yz = 0.0, .xz = 0.0, .yx = 0.0, .xw = 0, .yw = 0, .zw = 1 };
+    pub const wz_plane: Bivec4 = .{ .yz = 0.0, .xz = 0.0, .yx = 0.0, .xw = 0, .yw = 0, .zw = -1 };
+
+    /// Checks for equality.
+    pub fn eql(self: Bivec4, other: Bivec4) bool {
+        return std.meta.eql(self, other);
+    }
+
+    test eql {
+        try std.testing.expect(Bivec4.zero.eql(.zero));
+        try std.testing.expect(!Bivec4.zero.eql(.yz_plane));
+        try std.testing.expect(!Bivec4.zero.eql(.zy_plane));
+        try std.testing.expect(!Bivec4.zero.eql(.xz_plane));
+        try std.testing.expect(!Bivec4.zero.eql(.zx_plane));
+        try std.testing.expect(!Bivec4.zero.eql(.yx_plane));
+        try std.testing.expect(!Bivec4.zero.eql(.xy_plane));
+        try std.testing.expect(!Bivec4.zero.eql(.xw_plane));
+        try std.testing.expect(!Bivec4.zero.eql(.wx_plane));
+        try std.testing.expect(!Bivec4.zero.eql(.yw_plane));
+        try std.testing.expect(!Bivec4.zero.eql(.wy_plane));
+        try std.testing.expect(!Bivec4.zero.eql(.zw_plane));
+        try std.testing.expect(!Bivec4.zero.eql(.wz_plane));
+    }
+
+    /// Returns the bivector scaled by `factor`.
+    pub fn scaled(self: Bivec4, factor: f32) Bivec4 {
+        return .{
+            .yz = self.yz * factor,
+            .xz = self.xz * factor,
+            .yx = self.yx * factor,
+            .xw = self.xw * factor,
+            .yw = self.yw * factor,
+            .zw = self.zw * factor,
+        };
+    }
+
+    test scaled {
+        var b: Bivec4 = .{ .yz = 1.0, .xz = 2.0, .yx = 3.0, .xw = 4.0, .yw = 5.0, .zw = 6.0 };
+        b = b.scaled(2.0);
+        try std.testing.expectEqual(Bivec4{
+            .yz = 2.0,
+            .xz = 4.0,
+            .yx = 6.0,
+            .xw = 8.0,
+            .yw = 10.0,
+            .zw = 12.0,
+        }, b);
+    }
+
+    /// Scales the bivector by factor.
+    pub fn scale(self: *Bivec4, factor: f32) void {
+        self.* = self.scaled(factor);
+    }
+
+    test scale {
+        var b: Bivec4 = .{ .yz = 1.0, .xz = 2.0, .yx = 3.0, .xw = 4.0, .yw = 5.0, .zw = 6.0 };
+        b.scale(2.0);
+        try std.testing.expectEqual(Bivec4{
+            .yz = 2.0,
+            .xz = 4.0,
+            .yx = 6.0,
+            .xw = 8,
+            .yw = 10,
+            .zw = 12,
+        }, b);
+    }
+
+    /// Returns the bivector renormalized. Assumes the input is already near normal.
+    pub fn renormalized(self: Bivec4) Bivec4 {
+        const mag_sq = self.magSq();
+        return self.scaled(geom.invSqrtNearOne(mag_sq));
+    }
+
+    test renormalized {
+        var b: Bivec4 = .{ .yz = 1.05, .xz = 0.0, .yx = 0.0, .xw = 0.0, .yw = 0.0, .zw = 0.0 };
+        b = b.renormalized();
+        try std.testing.expectApproxEqAbs(b.yz, 1.0, 0.01);
+        try std.testing.expectEqual(b.xz, 0.0);
+        try std.testing.expectEqual(b.yx, 0.0);
+        try std.testing.expectEqual(b.xw, 0.0);
+        try std.testing.expectEqual(b.yw, 0.0);
+        try std.testing.expectEqual(b.zw, 0.0);
+    }
+
+    /// Normalizes the bivector. See `normalized`.
+    pub fn renormalize(self: *Bivec4) void {
+        self.* = self.normalized();
+    }
+
+    test renormalize {
+        var b: Bivec4 = .{ .yz = 1.05, .xz = 0.0, .yx = 0.0, .xw = 0.0, .yw = 0.0, .zw = 0.0 };
+        b.renormalize();
+        try std.testing.expectApproxEqAbs(b.yz, 1.0, 0.01);
+        try std.testing.expectEqual(b.xz, 0.0);
+        try std.testing.expectEqual(b.yx, 0.0);
+        try std.testing.expectEqual(b.xw, 0.0);
+        try std.testing.expectEqual(b.yw, 0.0);
+        try std.testing.expectEqual(b.zw, 0.0);
+    }
+
+    /// Returns the normalized bivector. If the bivector is 0, it is returned unchanged. If your
+    /// input is nearly normal already, consider using `renormalized` instead.
+    pub fn normalized(self: Bivec4) Bivec4 {
+        const mag_sq = self.magSq();
+        if (mag_sq == 0) return self;
+        return self.scaled(geom.invSqrt(mag_sq));
+    }
+
+    test normalized {
+        var b: Bivec4 = .{ .yz = 10.0, .xz = 0.0, .yx = 0.0, .xw = 0, .yw = 0, .zw = 0 };
+        b = b.normalized();
+        try std.testing.expectEqual(Bivec4{
+            .yz = 1.0,
+            .xz = 0.0,
+            .yx = 0.0,
+            .xw = 0,
+            .yw = 0,
+            .zw = 0,
+        }, b);
+        try std.testing.expectEqual(Bivec4.zero, Bivec4.zero.normalized());
+    }
+
+    /// Normalizes the bivector. See `normalized`.
+    pub fn normalize(self: *Bivec4) void {
+        self.* = self.normalized();
+    }
+
+    test normalize {
+        var b: Bivec4 = .{ .yz = 10.0, .xz = 0.0, .yx = 0.0, .xw = 0.0, .yw = 0.0, .zw = 0.0 };
+        b.normalize();
+        try std.testing.expectEqual(
+            Bivec4{ .yz = 1, .xz = 0, .yx = 0, .xw = 0, .yw = 0, .zw = 0 },
+            b,
+        );
+        b = .zero;
+        b.normalize();
+        try std.testing.expectEqual(Bivec4.zero, b);
+    }
+
+    pub fn magSq(self: Bivec4) f32 {
+        return @mulAdd(f32, self.yz, self.yz, @mulAdd(f32, self.xz, self.xz, self.yx * self.yx)) +
+            @mulAdd(f32, self.xw, self.xw, @mulAdd(f32, self.yw, self.yw, self.zw * self.zw));
+    }
+
+    test magSq {
+        const b: Bivec4 = .{ .yz = 2.0, .xz = 3.0, .yx = 4.0, .xw = 5.0, .yw = 6.0, .zw = 7.0 };
+        try std.testing.expectEqual(139.0, b.magSq());
+    }
+
+    /// Returns the magnitude of the bivector.
+    pub fn mag(self: Bivec4) f32 {
+        return @sqrt(self.magSq());
+    }
+
+    test mag {
+        const b: Bivec4 = .{ .yz = 2.0, .xz = 3.0, .yx = 4.0, .xw = 5.0, .yw = 6.0, .zw = 7.0 };
+        try std.testing.expectEqual(@sqrt(139.0), b.mag());
+    }
+
+    /// Returns the inner product of two bivectors, which results in a scalar representing the
+    /// extent to which they occupy the same plane. This is similar to the dot product.
+    pub fn innerProd(lhs: Bivec4, rhs: Bivec4) f32 {
+        return @mulAdd(f32, -lhs.yz, rhs.yz, @mulAdd(f32, -3.0, rhs.xz, -lhs.yx * rhs.yx)) +
+            @mulAdd(f32, -lhs.xw, rhs.xw, @mulAdd(f32, -lhs.yw, rhs.yw, -lhs.zw * rhs.zw));
+    }
+
+    test innerProd {
+        const a: Bivec4 = .{ .yz = 2.0, .xz = 3.0, .yx = 4.0, .xw = 5.0, .yw = 6.0, .zw = 7.0 };
+        const b: Bivec4 = .{ .yz = 8.0, .xz = 9.0, .yx = 10.0, .xw = 11.0, .yw = 12.0, .zw = 13.0 };
+        try std.testing.expectEqual(-301, a.innerProd(b));
+    }
+
+    pub fn outerProd(lhs: Bivec4, rhs: Vec4) Trivec4 {
+        return .{
+            .yzw = @mulAdd(f32, lhs.yz, rhs.w, @mulAdd(f32, -lhs.yw, rhs.z, lhs.zw * rhs.y)),
+            .xzw = @mulAdd(f32, lhs.xz, rhs.w, @mulAdd(f32, -lhs.xw, rhs.z, lhs.zw * rhs.x)),
+            .yxw = @mulAdd(f32, lhs.yx, rhs.w, @mulAdd(f32, lhs.xw, rhs.y, -lhs.yw * rhs.x)),
+            .xyz = @mulAdd(f32, -lhs.yx, rhs.z, @mulAdd(f32, -lhs.xz, rhs.y, lhs.yz * rhs.x)),
+        };
+    }
+
+    test outerProd {
+        const a: Bivec4 = .{ .yz = 2.0, .xz = 3.0, .yx = 4.0, .xw = 5.0, .yw = 6.0, .zw = 7.0 };
+        const b: Vec4 = .{ .x = 8, .y = 9, .z = 10, .w = 11 };
+        const c: Trivec4 = .{
+            .yzw = 25.0,
+            .xzw = 39.0,
+            .xyz = -51.0,
+            .yxw = 41.0,
+        };
+        try std.testing.expectEqual(c, a.outerProd(b));
+    }
+
+    pub fn outerProdVec4(lhs: Bivec4, rhs: Vec4) Trivec4 {
+        return rhs.outerProdBivec4(lhs);
+    }
+
+    test outerProdVec4 {
+        const a: Bivec4 = .{
+            .yz = 5,
+            .xz = 6,
+            .yx = 7,
+            .xw = 8,
+            .yw = 9,
+            .zw = 10,
+        };
+        const b: Vec4 = .{ .x = 1, .y = 2, .z = 3, .w = 4 };
+        try std.testing.expectEqual(Trivec4{
+            .yzw = 13,
+            .xzw = 10,
+            .yxw = 35,
+            .xyz = -28,
+        }, a.outerProdVec4(b));
+    }
+
+    // XXX: name inverse vs negate?
+    /// Returns bivector negated.
+    pub fn negated(self: Bivec4) Bivec4 {
+        return self.scaled(-1);
+    }
+
+    test negated {
+        var v: Bivec4 = .{
+            .yz = 1,
+            .xz = 2,
+            .yx = 3,
+            .xw = 4,
+            .yw = 5,
+            .zw = 6,
+        };
+        v = v.negated();
+        try std.testing.expectEqual(Bivec4{
+            .yz = -1,
+            .xz = -2,
+            .yx = -3,
+            .xw = -4,
+            .yw = -5,
+            .zw = -6,
+        }, v);
+    }
+
+    /// Negates the bivector.
+    pub fn negate(self: *Bivec4) void {
+        self.* = self.negated();
+    }
+
+    test negate {
+        var v: Bivec4 = .{
+            .yz = 1,
+            .xz = 2,
+            .yx = 3,
+            .xw = 4,
+            .yw = 5,
+            .zw = 6,
+        };
+        v.negate();
+        try std.testing.expectEqual(Bivec4{
+            .yz = -1,
+            .xz = -2,
+            .yx = -3,
+            .xw = -4,
+            .yw = -5,
+            .zw = -6,
+        }, v);
+    }
+
+    /// Returns self multiplied by wzyx, results in the orthogonal bivector with a magnitude of the
+    /// oriented area.
+    pub fn dual(self: Bivec4) Bivec4 {
+        // XXX: verify
+        return .{
+            .yz = -self.xw,
+            .xz = self.yw,
+            .yx = self.zw,
+            .xw = -self.yz,
+            .yw = self.xz,
+            .zw = self.yx,
+        };
+    }
+
+    test dual {
+        const a: Bivec4 = .{
+            .yz = 1,
+            .xz = 2,
+            .yx = 3,
+            .xw = 4,
+            .yw = 5,
+            .zw = 6,
+        };
+        const b: Bivec4 = .{
+            .yz = -4,
+            .xz = 5,
+            .yx = 6,
+            .xw = -1,
+            .yw = 2,
+            .zw = 3,
+        };
+        try std.testing.expectEqual(b, a.dual());
+        try std.testing.expectEqual(a, a.dual().dual().dual().dual());
+        // XXX: fails?
+        // try std.testing.expectEqual(a.negated(), a.dual().dual());
+        // try std.testing.expectEqual(a.negated().yx, a.dual().dual().yx);
+    }
+};

--- a/src/frustum3.zig
+++ b/src/frustum3.zig
@@ -5,7 +5,9 @@ const remap = geom.tween.interp.remap;
 
 const Vec2 = geom.Vec2;
 const Vec3 = geom.Vec3;
+const Vec4 = geom.Vec4;
 const Mat4 = geom.Mat4;
+const Trivec4 = geom.Trivec4;
 
 /// A 3 dimensional frustum.
 pub const Frustum3 = extern struct {
@@ -66,6 +68,108 @@ pub const Frustum3 = extern struct {
         const p_ndc = proj.timesPoint(p_view);
         const un = f.unprojectOrtho(p_ndc.xy());
         try expectVec2ApproxEql(p_view.xy(), un);
+    }
+
+    // XXX: do enough to get this working, and then get book for rest to fill in
+    pub fn unprojectPerspectiveOntoPlane(f: Frustum3, ndc: Vec2, plane: Trivec4) ?Vec3 {
+        // Unproject the cursor into a line
+        const near_intersect = unprojectPerspective(f, ndc, f.near);
+        const far_intersect = unprojectPerspective(f, ndc, f.far);
+        const line = near_intersect.point().outerProd(far_intersect.point());
+
+        // Get the intersection between that line and the given plane
+        const plane_intersect = plane.meet(line).toCartesian();
+
+        // If the intersection isn't between the near and far plane, return null
+        const near_dist_sq = plane_intersect.minus(near_intersect).magSq();
+        const far_dist_sq = plane_intersect.minus(far_intersect).magSq();
+        const depth_sq = near_intersect.minus(far_intersect).magSq();
+
+        if (near_dist_sq + far_dist_sq > depth_sq) {
+            return null;
+        }
+
+        // XXX: why would this happen again?
+        // If we got NaN for the intersection, return null
+        if (plane_intersect.x != plane_intersect.x or
+            plane_intersect.y != plane_intersect.y or
+            plane_intersect.z != plane_intersect.z)
+        {
+            return null;
+        }
+
+        // Return the intersection
+        return plane_intersect;
+    }
+
+    // XXX: ...
+    // XXX: test exact equal in cases we care about?
+    // XXX: test in game
+    test unprojectPerspectiveOntoPlane {
+        const f: Frustum3 = .{
+            .left = -2.5,
+            .right = 0.3,
+            .top = 4.1,
+            .bottom = -2.2,
+            .near = 0.15,
+            .far = 3.2,
+        };
+        const proj_from_view: Mat4 = .perspectiveFromFrustum(f);
+
+        {
+            const a: Vec3 = .{ .x = 0, .y = 0, .z = f.near };
+            const b: Vec3 = .{ .x = 1, .y = 0, .z = f.near };
+            const c: Vec3 = .{ .x = 0, .y = 1, .z = f.near };
+            const plane = a.point().outerProd(b.point()).outerProd(c.point());
+            const ndc = Vec2.zero;
+            const unprojected = unprojectPerspectiveOntoPlane(f, ndc, plane).?;
+            const projected = proj_from_view.timesPoint(unprojected);
+            try expectVec2ApproxEql(projected.xy(), ndc);
+        }
+
+        {
+            const a: Vec3 = .{ .x = 0, .y = 0, .z = 1 };
+            const b: Vec3 = .{ .x = 1, .y = 0, .z = 1 };
+            const c: Vec3 = .{ .x = 0, .y = 1, .z = 1 };
+            const plane = a.point().outerProd(b.point()).outerProd(c.point());
+            const ndc = Vec2.zero;
+            const unprojected = unprojectPerspectiveOntoPlane(f, ndc, plane).?;
+            const projected = proj_from_view.timesPoint(unprojected);
+            try expectVec2ApproxEql(projected.xy(), ndc);
+        }
+
+        {
+            const a: Vec3 = .{ .x = 0, .y = 0, .z = 1 };
+            const b: Vec3 = .{ .x = 1, .y = 0, .z = 1 };
+            const c: Vec3 = .{ .x = 0, .y = 1, .z = 1 };
+            const plane = a.point().outerProd(b.point()).outerProd(c.point());
+            const ndc: Vec2 = .{ .x = 1, .y = 1 };
+            const unprojected = unprojectPerspectiveOntoPlane(f, ndc, plane).?;
+            const projected = proj_from_view.timesPoint(unprojected);
+            try expectVec2ApproxEql(projected.xy(), ndc);
+        }
+
+        {
+            const a: Vec3 = .{ .x = 0, .y = 0, .z = f.far };
+            const b: Vec3 = .{ .x = 1, .y = 0, .z = f.far };
+            const c: Vec3 = .{ .x = 0, .y = 1, .z = f.far };
+            const plane = a.point().outerProd(b.point()).outerProd(c.point());
+            const ndc = Vec2.zero;
+            const unprojected = unprojectPerspectiveOntoPlane(f, ndc, plane).?;
+            const projected = proj_from_view.timesPoint(unprojected);
+            try expectVec2ApproxEql(projected.xy(), ndc);
+        }
+
+        {
+            const a: Vec3 = .{ .x = 0, .y = 0, .z = f.far };
+            const b: Vec3 = .{ .x = 1, .y = 0, .z = f.far };
+            const c: Vec3 = .{ .x = 0, .y = 1, .z = f.far };
+            const plane = a.point().outerProd(b.point()).outerProd(c.point());
+            const ndc: Vec2 = .{ .x = 1, .y = 1 };
+            const unprojected = unprojectPerspectiveOntoPlane(f, ndc, plane).?;
+            const projected = proj_from_view.timesPoint(unprojected);
+            try expectVec2ApproxEql(projected.xy(), ndc);
+        }
     }
 };
 

--- a/src/root.zig
+++ b/src/root.zig
@@ -8,6 +8,7 @@ pub const Vec3 = @import("vec3.zig").Vec3;
 pub const Vec4 = @import("vec4.zig").Vec4;
 pub const Bivec2 = @import("bivec2.zig").Bivec2;
 pub const Bivec3 = @import("bivec3.zig").Bivec3;
+pub const Bivec4 = @import("bivec4.zig").Bivec4;
 pub const Rotor2 = @import("rotor2.zig").Rotor2;
 pub const Rotor3 = @import("rotor3.zig").Rotor3;
 pub const Mat2 = @import("mat2.zig").Mat2;
@@ -17,6 +18,7 @@ pub const Mat3x4 = @import("mat3x4.zig").Mat3x4;
 pub const Mat4 = @import("mat4.zig").Mat4;
 pub const Frustum2 = @import("frustum2.zig").Frustum2;
 pub const Frustum3 = @import("frustum3.zig").Frustum3;
+pub const Trivec4 = @import("trivec4.zig").Trivec4;
 
 pub const constants = @import("constants.zig");
 pub const hash = @import("hash.zig");

--- a/src/rotor2.zig
+++ b/src/rotor2.zig
@@ -9,6 +9,7 @@ const Bivec2 = geom.Bivec2;
 
 const lerp = tween.interp.lerp;
 
+// XXX: dual of this?
 /// A two dimensional rotor. Rotors are a generalized form of quaternions which are used for
 /// rotation. Unlike quaternions, rotors generalize to all dimensions. Rotors can represent up to
 /// two full rotations, at which point they wrap back around.

--- a/src/rotor3.zig
+++ b/src/rotor3.zig
@@ -9,6 +9,7 @@ const Bivec3 = geom.Bivec3;
 
 const lerp = tween.interp.lerp;
 
+// XXX: dual of this?
 /// A three dimensional rotor. Rotors are a generalized form of quaternions which are used for
 /// rotation. Unlike quaternions, rotors generalize to all dimensions. Rotors can represent up to
 /// two full rotations, at which point they wrap back around.

--- a/src/trivec4.zig
+++ b/src/trivec4.zig
@@ -1,0 +1,821 @@
+const std = @import("std");
+const geom = @import("root.zig");
+
+const Vec4 = geom.Vec4;
+const Bivec4 = geom.Bivec4;
+
+// XXX: add duals to vectors?
+// XXX: document, used for plucker/homogenous coords I think? update consts?
+// XXX: do we also need bivec4?
+// XXX: check math
+pub const Trivec4 = extern struct {
+    yzw: f32,
+    xzw: f32,
+    yxw: f32,
+    xyz: f32,
+
+    pub const zero: Trivec4 = .{ .yzw = 0, .xzw = 0, .yxw = 0, .xyz = 0 };
+
+    /// Checks for equality.
+    pub fn eql(self: Trivec4, other: Trivec4) bool {
+        return std.meta.eql(self, other);
+    }
+    test eql {
+        const a: Trivec4 = .zero;
+        const b: Trivec4 = .{
+            .yzw = 0,
+            .xzw = 0,
+            .yxw = 0,
+            .xyz = 1,
+        };
+        try std.testing.expect(a.eql(a));
+        try std.testing.expect(!a.eql(b));
+    }
+
+    /// Returns self multiplied by wzyx, resulting in a vector orthogonal to the oriented volume.
+    pub fn dual(self: Trivec4) Vec4 {
+        // XXX: why did i get all these flipped? wait but if i DONT do that, then the dual dual works..?
+        return .{
+            .x = self.yzw,
+            .y = -self.xzw,
+            .z = -self.yxw,
+            .w = -self.xyz,
+        };
+    }
+
+    test dual {
+        const a: Trivec4 = .{
+            .yzw = 1,
+            .xzw = 2,
+            .yxw = 3,
+            .xyz = 4,
+        };
+        // try std.testing.expectEqual(Vec4{
+        //     .x = -1,
+        //     .y = 2,
+        //     .z = 3,
+        //     .w = 4,
+        // }, a.dual());
+        try std.testing.expectEqual(a, a.dual().dual().dual().dual());
+        // XXX: why does this fail?
+        try std.testing.expectEqual(a.inverse(), a.dual().dual());
+    }
+
+    pub fn scaled(self: Trivec4, factor: f32) Trivec4 {
+        return .{
+            .yzw = self.yzw * factor,
+            .xzw = self.xzw * factor,
+            .yxw = self.yxw * factor,
+            .xyz = self.xyz * factor,
+        };
+    }
+
+    test scaled {
+        const a: Trivec4 = .{
+            .yzw = 2,
+            .xzw = 3,
+            .yxw = 1,
+            .xyz = 4,
+        };
+        const b: Trivec4 = .{
+            .yzw = 4,
+            .xzw = 6,
+            .yxw = 2,
+            .xyz = 8,
+        };
+        try std.testing.expectEqual(b, a.scaled(2));
+    }
+
+    pub fn scale(self: *Trivec4, factor: f32) void {
+        self.* = self.scaled(factor);
+    }
+
+    test scale {
+        var a: Trivec4 = .{
+            .yzw = 2,
+            .xzw = 3,
+            .yxw = 1,
+            .xyz = 4,
+        };
+        a.scale(2);
+        const b: Trivec4 = .{
+            .yzw = 4,
+            .xzw = 6,
+            .yxw = 2,
+            .xyz = 8,
+        };
+        try std.testing.expectEqual(b, a);
+    }
+
+    pub fn inverse(self: Trivec4) Trivec4 {
+        return .{
+            .yzw = -self.yzw,
+            .xzw = -self.xzw,
+            .yxw = -self.yxw,
+            .xyz = -self.xyz,
+        };
+    }
+
+    test inverse {
+        const a: Trivec4 = .{
+            .yzw = 2,
+            .xzw = 3,
+            .yxw = 1,
+            .xyz = 4,
+        };
+        const b: Trivec4 = .{
+            .yzw = -2,
+            .xzw = -3,
+            .yxw = -1,
+            .xyz = -4,
+        };
+        try std.testing.expectEqual(b, a.inverse());
+    }
+
+    pub fn invert(self: *Trivec4) void {
+        self.* = self.inverse();
+    }
+
+    test invert {
+        var a: Trivec4 = .{
+            .yzw = 2,
+            .xzw = 3,
+            .yxw = 1,
+            .xyz = 4,
+        };
+        a.invert();
+        const b: Trivec4 = .{
+            .yzw = -2,
+            .xzw = -3,
+            .yxw = -1,
+            .xyz = -4,
+        };
+        try std.testing.expectEqual(b, a);
+    }
+
+    pub fn magSq(self: Trivec4) f32 {
+        return @mulAdd(f32, self.yxw, self.yxw, self.xzw * self.xzw) +
+            @mulAdd(f32, self.yzw, self.yzw, self.xyz * self.xyz);
+    }
+
+    test magSq {
+        const v: Trivec4 = .{ .yzw = 2, .xzw = 3, .yxw = 4, .xyz = 5 };
+        try std.testing.expectEqual(54, v.magSq());
+    }
+
+    pub fn mag(self: Trivec4) f32 {
+        return @sqrt(self.magSq());
+    }
+
+    test mag {
+        const v: Trivec4 = .{ .yzw = 2, .xzw = 3, .yxw = 4, .xyz = 5 };
+        try std.testing.expectEqual(@sqrt(54.0), v.mag());
+    }
+
+    /// Returns the vector renormalized. Assumes the input is already near normal.
+    pub fn renormalized(self: Trivec4) Trivec4 {
+        const mag_sq = self.magSq();
+        if (mag_sq == 0) return self;
+        return self.scaled(geom.invSqrtNearOne(mag_sq));
+    }
+
+    test renormalized {
+        var v: Trivec4 = .{ .yzw = 0.0, .xzw = 0.0, .yxw = 1.05, .xyz = 0.0 };
+        v = v.renormalized();
+        try std.testing.expectEqual(v.yzw, 0.0);
+        try std.testing.expectEqual(v.xzw, 0.0);
+        try std.testing.expectApproxEqAbs(v.yxw, 1.0, 0.01);
+        try std.testing.expectEqual(v.xyz, 0.0);
+    }
+
+    /// Renormalizes the vector. See `renormalized`.
+    pub fn renormalize(self: *Trivec4) void {
+        self.* = self.renormalized();
+    }
+
+    test renormalize {
+        var v: Trivec4 = .{ .yzw = 0.0, .xzw = 0.0, .yxw = 1.05, .xyz = 0.0 };
+        v.renormalize();
+        try std.testing.expectEqual(v.yzw, 0.0);
+        try std.testing.expectEqual(v.xzw, 0.0);
+        try std.testing.expectApproxEqAbs(v.yxw, 1.0, 0.01);
+        try std.testing.expectEqual(v.xyz, 0.0);
+    }
+
+    /// Returns the vector normalized. If the trivector is `.zero`, returns it unchanged. If your
+    /// input is nearly normal already, consider using `renormalize` instead.
+    pub fn normalized(self: Trivec4) Trivec4 {
+        const mag_sq = self.magSq();
+        if (mag_sq == 0) return self;
+        return self.scaled(geom.invSqrt(mag_sq));
+    }
+
+    test normalized {
+        var v: Trivec4 = .{ .yzw = 0.0, .xzw = 0.0, .yxw = 10.0, .xyz = 0.0 };
+        v = v.normalized();
+        try std.testing.expectEqual(Trivec4{ .yzw = 0.0, .xzw = 0.0, .yxw = 1.0, .xyz = 0.0 }, v);
+        try std.testing.expectEqual(zero, normalized(.zero));
+    }
+
+    /// Normalizes the vector. See `normalized`.
+    pub fn normalize(self: *Trivec4) void {
+        self.* = self.normalized();
+    }
+
+    test normalize {
+        var v: Trivec4 = .{ .yzw = 0.0, .xzw = 0.0, .yxw = 10.0, .xyz = 0.0 };
+        v.normalize();
+        try std.testing.expectEqual(Trivec4{ .yzw = 0.0, .xzw = 0.0, .yxw = 1.0, .xyz = 0.0 }, v);
+        v = .zero;
+        v.normalize();
+        try std.testing.expectEqual(zero, v);
+    }
+
+    pub fn innerProduct(lhs: Trivec4, rhs: Trivec4) f32 {
+        return @mulAdd(f32, -lhs.yxw, rhs.yxw, -lhs.xzw * rhs.xzw) -
+            @mulAdd(f32, lhs.yzw, rhs.yzw, lhs.xyz * rhs.xyz);
+    }
+
+    test innerProduct {
+        const a: Trivec4 = .{
+            .yzw = 2,
+            .xzw = 3,
+            .yxw = 1,
+            .xyz = 4,
+        };
+        const b: Trivec4 = .{
+            .yzw = 6,
+            .xzw = 7,
+            .yxw = 5,
+            .xyz = 8,
+        };
+        try std.testing.expectEqual(-70, a.innerProduct(b));
+    }
+
+    // XXX: test...name after what meeting with?
+    pub fn meet(self: Trivec4, rhs: Bivec4) Vec4 {
+        return self.join(rhs).dual();
+    }
+
+    // XXX: test...
+    pub fn join(self: Trivec4, rhs: Bivec4) Trivec4 {
+        return self.dual().outerProdBivec4(rhs.dual());
+    }
+};
+
+// XXX: ...
+// #[test]
+// fn test_create_homogeneous_line() {
+//     // Test creating a line from a normalized point on the origin and a normalized point off of it
+//     let a = math::vec4(0.0, 0.0, 0.0, 1.0);
+//     let b = math::vec4(1.0, 0.0, 0.0, 1.0);
+//     std::assert(bivec4_eq(
+//         vec4_vec4_outer_product(a, b),
+//         Bivec4 { xy: 0.0, zx: 0.0, yz: 0.0, xw: -1.0, yw: 0.0, zw: 0.0 },
+//     ));
+//     std::assert(bivec4_eq(
+//         vec4_vec4_outer_product(b, a),
+//         Bivec4 { xy: 0.0, zx: 0.0, yz: 0.0, xw: 1.0, yw: 0.0, zw: 0.0 },
+//     ));
+
+//     let a = math::vec4(0.0, 0.0, 0.0, 1.0);
+//     let b = math::vec4(0.0, 1.0, 0.0, 1.0);
+//     std::assert(bivec4_eq(
+//         vec4_vec4_outer_product(a, b),
+//         Bivec4 { xy: 0.0, zx: 0.0, yz: 0.0, xw: 0.0, yw: -1.0, zw: 0.0 },
+//     ));
+//     std::assert(bivec4_eq(
+//         vec4_vec4_outer_product(b, a),
+//         Bivec4 { xy: 0.0, zx: 0.0, yz: 0.0, xw: 0.0, yw: 1.0, zw: 0.0 },
+//     ));
+
+//     let a = math::vec4(0.0, 0.0, 0.0, 1.0);
+//     let b = math::vec4(0.0, 0.0, 1.0, 1.0);
+//     std::assert(bivec4_eq(
+//         vec4_vec4_outer_product(a, b),
+//         Bivec4 { xy: 0.0, zx: 0.0, yz: 0.0, xw: 0.0, yw: 0.0, zw: -1.0 },
+//     ));
+//     std::assert(bivec4_eq(
+//         vec4_vec4_outer_product(b, a),
+//         Bivec4 { xy: 0.0, zx: 0.0, yz: 0.0, xw: 0.0, yw: 0.0, zw: 1.0 },
+//     ));
+
+//     let a = math::vec4(0.0, 0.0, 0.0, 1.0);
+//     let b = math::vec4(1.0, 1.0, 1.0, 1.0);
+//     std::assert(bivec4_eq(
+//         vec4_vec4_outer_product(a, b),
+//         Bivec4 { xy: 0.0, zx: 0.0, yz: 0.0, xw: -1.0, yw: -1.0, zw: -1.0 },
+//     ));
+//     std::assert(bivec4_eq(
+//         vec4_vec4_outer_product(b, a),
+//         Bivec4 { xy: 0.0, zx: 0.0, yz: 0.0, xw: 1.0, yw: 1.0, zw: 1.0 },
+//     ));
+
+//     // Test creating a line two normalized points off of the origin
+//     let a = math::vec4(1.0, 0.0, 0.0, 1.0);
+//     let b = math::vec4(1.0, 1.0, 0.0, 1.0);
+//     std::assert(bivec4_eq(
+//         vec4_vec4_outer_product(a, b),
+//         Bivec4 { xy: 1.0, zx: 0.0, yz: 0.0, xw: 0.0, yw: -1.0, zw: 0.0 },
+//     ));
+//     std::assert(bivec4_eq(
+//         vec4_vec4_outer_product(b, a),
+//         Bivec4 { xy: -1.0, zx: 0.0, yz: 0.0, xw: 0.0, yw: 1.0, zw: 0.0 },
+//     ));
+
+//     let a = math::vec4(-1.0, 1.0, 0.0, 1.0);
+//     let b = math::vec4(1.0, 1.0, 0.0, 1.0);
+//     std::assert(bivec4_eq(
+//         vec4_vec4_outer_product(a, b),
+//         Bivec4 { xy: -2.0, zx: 0.0, yz: 0.0, xw: -2.0, yw: 0.0, zw: 0.0 },
+//     ));
+//     std::assert(bivec4_eq(
+//         vec4_vec4_outer_product(b, a),
+//         Bivec4 { xy: 2.0, zx: 0.0, yz: 0.0, xw: 2.0, yw: 0.0, zw: 0.0 },
+//     ));
+
+//     let a = math::vec4(3.0, 0.0, 0.0, 1.0);
+//     let b = math::vec4(3.0, 0.0, 2.0, 1.0);
+//     std::assert(bivec4_eq(
+//         vec4_vec4_outer_product(a, b),
+//         Bivec4 { xy: 0.0, zx: -6.0, yz: 0.0, xw: 0.0, yw: 0.0, zw: -2.0 },
+//     ));
+//     std::assert(bivec4_eq(
+//         vec4_vec4_outer_product(b, a),
+//         Bivec4 { xy: 0.0, zx: 6.0, yz: 0.0, xw: 0.0, yw: 0.0, zw: 2.0 },
+//     ));
+
+//     let a = math::vec4(0.0, 0.0, 1.0, 1.0);
+//     let b = math::vec4(2.0, 0.0, 1.0, 1.0);
+//     std::assert(bivec4_eq(
+//         vec4_vec4_outer_product(a, b),
+//         Bivec4 { xy: 0.0, zx: 2.0, yz: 0.0, xw: -2.0, yw: 0.0, zw: 0.0 },
+//     ));
+//     std::assert(bivec4_eq(
+//         vec4_vec4_outer_product(b, a),
+//         Bivec4 { xy: 0.0, zx: -2.0, yz: 0.0, xw: 2.0, yw: 0.0, zw: 0.0 },
+//     ));
+
+//     // Test creating a line from a point and a direction
+//     let a = math::vec4(1.0, 0.0, 0.0, 1.0);
+//     let b = math::vec4(1.0, 0.0, 0.0, 0.0);
+//     std::assert(bivec4_eq(
+//         vec4_vec4_outer_product(a, b),
+//         Bivec4 { xy: 0.0, zx: 0.0, yz: 0.0, xw: -1.0, yw: 0.0, zw: 0.0 },
+//     ));
+//     std::assert(bivec4_eq(
+//         vec4_vec4_outer_product(b, a),
+//         Bivec4 { xy: 0.0, zx: 0.0, yz: 0.0, xw: 1.0, yw: 0.0, zw: 0.0 },
+//     ));
+
+//     let a = math::vec4(0.0, 0.0, 0.0, 1.0);
+//     let b = math::vec4(0.0, 1.0, 0.0, 0.0);
+//     std::assert(bivec4_eq(
+//         vec4_vec4_outer_product(a, b),
+//         Bivec4 { xy: 0.0, zx: 0.0, yz: 0.0, xw: 0.0, yw: -1.0, zw: 0.0 },
+//     ));
+//     std::assert(bivec4_eq(
+//         vec4_vec4_outer_product(b, a),
+//         Bivec4 { xy: 0.0, zx: 0.0, yz: 0.0, xw: 0.0, yw: 1.0, zw: 0.0 },
+//     ));
+
+//     let a = math::vec4(0.0, 0.0, 0.0, 1.0);
+//     let b = math::vec4(0.0, 0.0, 2.0, 0.0);
+//     std::assert(bivec4_eq(
+//         vec4_vec4_outer_product(a, b),
+//         Bivec4 { xy: 0.0, zx: 0.0, yz: 0.0, xw: 0.0, yw: 0.0, zw: -2.0 },
+//     ));
+//     std::assert(bivec4_eq(
+//         vec4_vec4_outer_product(b, a),
+//         Bivec4 { xy: 0.0, zx: 0.0, yz: 0.0, xw: 0.0, yw: 0.0, zw: 2.0 },
+//     ));
+
+//     let a = math::vec4(1.0, 1.0, 1.0, 1.0);
+//     let b = math::vec4(1.0, 1.0, 1.0, 0.0);
+//     std::assert(bivec4_eq(
+//         vec4_vec4_outer_product(a, b),
+//         Bivec4 { xy: 0.0, zx: 0.0, yz: 0.0, xw: -1.0, yw: -1.0, zw: -1.0 },
+//     ));
+//     std::assert(bivec4_eq(
+//         vec4_vec4_outer_product(b, a),
+//         Bivec4 { xy: 0.0, zx: 0.0, yz: 0.0, xw: 1.0, yw: 1.0, zw: 1.0 },
+//     ));
+
+//     let a = math::vec4(0.0, 1.0, 0.0, 1.0);
+//     let b = math::vec4(1.0, 0.0, 0.0, 0.0);
+//     std::assert(bivec4_eq(
+//         vec4_vec4_outer_product(a, b),
+//         Bivec4 { xy: -1.0, zx: 0.0, yz: 0.0, xw: -1.0, yw: 0.0, zw: 0.0 },
+//     ));
+//     std::assert(bivec4_eq(
+//         vec4_vec4_outer_product(b, a),
+//         Bivec4 { xy: 1.0, zx: 0.0, yz: 0.0, xw: 1.0, yw: 0.0, zw: 0.0 },
+//     ));
+
+//     // Test creating a line from points with non-normalized ws, and then normalizing the result
+//     let a = math::vec4(2.0, 0.0, 0.0, 2.0);
+//     let b = math::vec4(3.0, 3.0, 0.0, 3.0);
+//     let ab = vec4_vec4_outer_product(a, b);
+//     let ba = vec4_vec4_outer_product(b, a);
+//     std::assert(bivec4_eq(
+//         ab,
+//         Bivec4 { xy: 6.0, zx: 0.0, yz: 0.0, xw: 0.0, yw: -6.0, zw: 0.0 },
+//     ));
+//     std::assert(bivec4_eq(
+//         ba,
+//         Bivec4 { xy: -6.0, zx: 0.0, yz: 0.0, xw: 0.0, yw: 6.0, zw: 0.0 },
+//     ));
+//     let root2over2 = rmath::f32_sqrt(2.0) / 2.0;
+//     std::assert(bivec4_approx_eq(
+//         bivec4_normalize(ab),
+//         Bivec4 { xy: root2over2, zx: 0.0, yz: 0.0, xw: 0.0, yw: -root2over2, zw: 0.0 },
+//         rmath::F32_EPSILON,
+//     ));
+//     std::assert(bivec4_approx_eq(
+//         bivec4_normalize(ba),
+//         Bivec4 { xy: -root2over2, zx: 0.0, yz: 0.0, xw: 0.0, yw: root2over2, zw: 0.0 },
+//         rmath::F32_EPSILON,
+//     ));
+
+//     let a = math::vec4(0.0, 2.0, 0.0, 2.0);
+//     let b = math::vec4(0.0, 3.0, 3.0, 3.0);
+//     let ab = vec4_vec4_outer_product(a, b);
+//     let ba = vec4_vec4_outer_product(b, a);
+//     std::assert(bivec4_eq(
+//         ab,
+//         Bivec4 { xy: 0.0, zx: 0.0, yz: 6.0, xw: 0.0, yw: 0.0, zw: -6.0 },
+//     ));
+//     std::assert(bivec4_eq(
+//         ba,
+//         Bivec4 { xy: 0.0, zx: 0.0, yz: -6.0, xw: 0.0, yw: 0.0, zw: 6.0 },
+//     ));
+//     let root2over2 = rmath::f32_sqrt(2.0) / 2.0;
+//     std::assert(bivec4_approx_eq(
+//         bivec4_normalize(ab),
+//         Bivec4 { xy: 0.0, zx: 0.0, yz: root2over2, xw: 0.0, yw: 0.0, zw: -root2over2 },
+//         rmath::F32_EPSILON,
+//     ));
+//     std::assert(bivec4_approx_eq(
+//         bivec4_normalize(ba),
+//         Bivec4 { xy: 0.0, zx: 0.0, yz: -root2over2, xw: 0.0, yw: 0.0, zw: root2over2 },
+//         rmath::F32_EPSILON,
+//     ));
+
+//     // Test that two directions results in just the bivector components being set
+//     let a = math::vec4(0.0, 1.0, 0.0, 0.0);
+//     let b = math::vec4(1.0, 0.0, 0.0, 0.0);
+//     std::assert(bivec4_eq(
+//         vec4_vec4_outer_product(a, b),
+//         Bivec4 { xy: -1.0, zx: 0.0, yz: 0.0, xw: 0.0, yw: 0.0, zw: 0.0 },
+//     ));
+//     std::assert(bivec4_eq(
+//         vec4_vec4_outer_product(b, a),
+//         Bivec4 { xy: 1.0, zx: 0.0, yz: 0.0, xw: 0.0, yw: 0.0, zw: 0.0 },
+//     ));
+
+//     // Test creating a line with two identical points
+//     let a = math::vec4(2.0, -3.0, 4.0, 1.0);
+//     std::assert(bivec4_eq(
+//         vec4_vec4_outer_product(a, a),
+//         Bivec4 { xy: 0.0, zx: 0.0, yz: 0.0, xw: 0.0, yw: 0.0, zw: 0.0 },
+//     ));
+// }
+
+// // XXX: ...
+// // #[test]
+// // fn test_create_homogeneous_plane() {
+// //     // Test creating a plane from 3 vec4s in various orders, and normalizing it.
+// //     fn test_plane(a: Vec4, b: Vec4, c: Vec4, expected: Trivec4, expected_normalized: Trivec4) {
+// //         std::assert(trivec4_eq(expected, bivec4_vec4_outer_product(
+// //             vec4_vec4_outer_product(a, b),
+// //             c,
+// //         )));
+// //         std::assert(trivec4_eq(expected, bivec4_vec4_outer_product(
+// //             vec4_vec4_outer_product(b, c),
+// //             a,
+// //         )));
+// //         std::assert(trivec4_eq(expected, bivec4_vec4_outer_product(
+// //             vec4_vec4_outer_product(c, a),
+// //             b,
+// //         )));
+// //         std::assert(trivec4_eq(expected, vec4_bivec4_outer_product(
+// //             a,
+// //             vec4_vec4_outer_product(b, c),
+// //         )));
+// //         std::assert(trivec4_eq(expected, vec4_bivec4_outer_product(
+// //             c,
+// //             vec4_vec4_outer_product(a, b),
+// //         )));
+// //         std::assert(trivec4_eq(expected, vec4_bivec4_outer_product(
+// //             b,
+// //             vec4_vec4_outer_product(c, a),
+// //         )));
+// //         std::assert(trivec4_eq(expected, vec4_vec4_vec4_outer_product(a, b, c)));
+// //         std::assert(trivec4_eq(expected, vec4_vec4_vec4_outer_product(c, a, b)));
+// //         std::assert(trivec4_eq(expected, vec4_vec4_vec4_outer_product(b, c, a)));
+
+// //         let expected_inv = trivec4_inverse(expected);
+
+// //         std::assert(trivec4_eq(expected_inv, bivec4_vec4_outer_product(
+// //             vec4_vec4_outer_product(a, c),
+// //             b,
+// //         )));
+// //         std::assert(trivec4_eq(expected_inv, bivec4_vec4_outer_product(
+// //             vec4_vec4_outer_product(c, b),
+// //             a,
+// //         )));
+// //         std::assert(trivec4_eq(expected_inv, bivec4_vec4_outer_product(
+// //             vec4_vec4_outer_product(b, a),
+// //             c,
+// //         )));
+// //         std::assert(trivec4_eq(expected_inv, vec4_bivec4_outer_product(
+// //             a,
+// //             vec4_vec4_outer_product(c, b),
+// //         )));
+// //         std::assert(trivec4_eq(expected_inv, vec4_bivec4_outer_product(
+// //             c,
+// //             vec4_vec4_outer_product(b, a),
+// //         )));
+// //         std::assert(trivec4_eq(expected_inv, vec4_bivec4_outer_product(
+// //             b,
+// //             vec4_vec4_outer_product(a, c),
+// //         )));
+// //         std::assert(trivec4_eq(expected_inv, vec4_vec4_vec4_outer_product(b, a, c)));
+// //         std::assert(trivec4_eq(expected_inv, vec4_vec4_vec4_outer_product(a, c, b)));
+// //         std::assert(trivec4_eq(expected_inv, vec4_vec4_vec4_outer_product(c, b, a)));
+
+// //         let normalized = trivec4_normalize(expected);
+// //         if (normalized.xyw == normalized.xyw) {
+// //             std::assert(trivec4_approx_eq(
+// //                 trivec4_normalize(expected),
+// //                 expected_normalized,
+// //                 rmath::F32_EPSILON * 100.0,
+// //             ));
+// //         } else {
+// //             std::assert(normalized.xyw != normalized.xyw);
+// //             std::assert(normalized.xzw != normalized.xzw);
+// //             std::assert(normalized.yzw != normalized.yzw);
+// //             std::assert(normalized.xyz != normalized.xyz);
+// //             std::assert(expected_normalized.xyw != expected_normalized.xyw);
+// //             std::assert(expected_normalized.xzw != expected_normalized.xzw);
+// //             std::assert(expected_normalized.yzw != expected_normalized.yzw);
+// //             std::assert(expected_normalized.xyz != expected_normalized.xyz);
+// //         }
+// //     }
+
+// //     // Test three points
+// //     let root2over2 = rmath::f32_sqrt(2.0) / 2.0;
+// //     test_plane(
+// //         math::vec4(1.0, 1.0, 1.0, 1.0),
+// //         math::vec4(2.0, 1.0, 1.0, 1.0),
+// //         math::vec4(1.0, 2.0, 1.0, 1.0),
+// //         Trivec4 { xyw: 1.0, xzw: 0.0, yzw: 0.0, xyz: 1.0 },
+// //         Trivec4 { xyw: root2over2, xzw: 0.0, yzw: 0.0, xyz: root2over2 },
+// //     );
+// //     let m = 137.252504531;
+// //     test_plane(
+// //         math::vec4(10.0, 2.0, 7.0, 2.0),
+// //         math::vec4(9.0, 2.0, 3.0, 0.5),
+// //         math::vec4(3.0, 2.0, 4.0, 5.0),
+// //         Trivec4 { xyw: 27.0, xzw: 120.5, yzw: -33.0, xyz: 50.0 },
+// //         Trivec4 { xyw: 27.0/m, xzw: 120.5/m, yzw: -33.0/m, xyz: 50.0/m },
+// //     );
+
+// //     // Test two points and a direction
+// //     test_plane(
+// //         math::vec4(1.0, 1.0, 1.0, 0.0),
+// //         math::vec4(1.0, 1.0, 1.0, 1.0),
+// //         math::vec4(2.0, 2.0, -2.0, 1.0),
+// //         Trivec4 { xyw: 0.0, xzw: -4.0, yzw: 4.0, xyz: 0.0 },
+// //         Trivec4 { xyw: 0.0, xzw: -root2over2, yzw: root2over2, xyz: 0.0 },
+// //     );
+
+// //     // Test all the same point
+// //     test_plane(
+// //         math::vec4(1.0, 2.0, 3.0, 1.0),
+// //         math::vec4(1.0, 2.0, 3.0, 1.0),
+// //         math::vec4(1.0, 2.0, 3.0, 1.0),
+// //         Trivec4 { xyw: 0.0, xzw: 0.0, yzw: 0.0, xyz: 0.0 },
+// //         Trivec4 { xyw: NaN, xzw: NaN, yzw: NaN, xyz: NaN },
+// //     );
+
+// //     // Test a line and a point on the line
+// //     test_plane(
+// //         math::vec4(1.0, 1.0, 1.0, 0.0),
+// //         math::vec4(1.0, 1.0, 1.0, 1.0),
+// //         math::vec4(2.0, 2.0, -2.0, 1.0),
+// //         Trivec4 { xyw: 0.0, xzw: -4.0, yzw: 4.0, xyz: 0.0 },
+// //         Trivec4 { xyw: 0.0, xzw: -root2over2, yzw: root2over2, xyz: 0.0 },
+// //     );
+
+// //     // Test three collinear points
+// //     test_plane(
+// //         math::vec4(1.0, 1.0, 1.0, 1.0),
+// //         math::vec4(2.0, 2.0, 2.0, 1.0),
+// //         math::vec4(3.0, 3.0, 3.0, 1.0),
+// //         Trivec4 { xyw: 0.0, xzw: 0.0, yzw: 0.0, xyz: 0.0 },
+// //         Trivec4 { xyw: NaN, xzw: NaN, yzw: NaN, xyz: NaN },
+// //     );
+
+// //     // Test two of the same point and one different point
+// //     test_plane(
+// //         math::vec4(1.0, 1.0, 1.0, 1.0),
+// //         math::vec4(1.0, 1.0, 1.0, 1.0),
+// //         math::vec4(10.0, -10.0, 5.0, 1.0),
+// //         Trivec4 { xyw: 0.0, xzw: 0.0, yzw: 0.0, xyz: 0.0 },
+// //         Trivec4 { xyw: NaN, xzw: NaN, yzw: NaN, xyz: NaN },
+// //     );
+// // }
+
+// // #[test]
+// // fn test_meet_bivec4_trivec4() {
+// //     // Test lines through the xy plane at the origin
+// //     let plane = vec4_vec4_vec4_outer_product(
+// //         math::vec4(1.0, 0.0, 0.0, 1.0),
+// //         math::vec4(0.0, 1.0, 0.0, 1.0),
+// //         math::vec4(0.0, 0.0, 0.0, 1.0),
+// //     );
+
+// //     let intersection = trivec4_bivec4_meet(plane, vec4_vec4_outer_product(
+// //         math::vec4(0.0, 0.0, 0.0, 1.0),
+// //         math::vec4(0.0, 0.0, 1.0, 1.0),
+// //     ));
+// //     std::assert(math::vec4_eq(intersection, math::vec4(0.0, 0.0, 0.0, -1.0)));
+
+// //     let intersection = trivec4_bivec4_meet(plane, vec4_vec4_outer_product(
+// //         math::vec4(0.0, 0.0, 1.0, 1.0),
+// //         math::vec4(0.0, 0.0, 0.0, 1.0),
+// //     ));
+// //     std::assert(math::vec4_eq(intersection, math::vec4(0.0, 0.0, 0.0, 1.0)));
+
+// //     let intersection = trivec4_bivec4_meet(plane, vec4_vec4_outer_product(
+// //         math::vec4(2.0, 3.0, 1.0, 1.0),
+// //         math::vec4(2.0, 3.0, 0.0, 1.0),
+// //     ));
+// //     std::assert(math::vec4_eq(intersection, math::vec4(2.0, 3.0, 0.0, 1.0)));
+
+// //     // Test lines through the xy plane off the origin
+// //     let plane = vec4_vec4_vec4_outer_product(
+// //         math::vec4(1.0, 0.0, 10.0, 1.0),
+// //         math::vec4(0.0, 1.0, 10.0, 1.0),
+// //         math::vec4(0.0, 0.0, 10.0, 1.0),
+// //     );
+// //     let intersection = trivec4_bivec4_meet(plane, vec4_vec4_outer_product(
+// //         math::vec4(2.0, 3.0, 1.0, 1.0),
+// //         math::vec4(2.0, 3.0, 0.0, 1.0),
+// //     ));
+// //     std::assert(math::vec4_eq(intersection, math::vec4(2.0, 3.0, 10.0, 1.0)));
+
+// //     // Test lines through the xz plane at the origin
+// //     let plane = vec4_vec4_vec4_outer_product(
+// //         math::vec4(1.0, 0.0, 0.0, 1.0),
+// //         math::vec4(0.0, 0.0, 1.0, 1.0),
+// //         math::vec4(0.0, 0.0, 0.0, 1.0),
+// //     );
+
+// //     let intersection = trivec4_bivec4_meet(plane, vec4_vec4_outer_product(
+// //         math::vec4(0.0, 0.0, 0.0, 1.0),
+// //         math::vec4(0.0, 1.0, 0.0, 1.0),
+// //     ));
+// //     std::assert(math::vec4_eq(intersection, math::vec4(0.0, 0.0, 0.0, 1.0)));
+
+// //     let intersection = trivec4_bivec4_meet(plane, vec4_vec4_outer_product(
+// //         math::vec4(0.0, 1.0, 0.0, 1.0),
+// //         math::vec4(0.0, 0.0, 0.0, 1.0),
+// //     ));
+// //     std::assert(math::vec4_eq(intersection, math::vec4(0.0, 0.0, 0.0, -1.0)));
+
+// //     let intersection = trivec4_bivec4_meet(plane, vec4_vec4_outer_product(
+// //         math::vec4(2.0, 0.0, 3.0, 1.0),
+// //         math::vec4(2.0, 1.0, 3.0, 1.0),
+// //     ));
+// //     std::assert(math::vec4_eq(intersection, math::vec4(2.0, 0.0, 3.0, 1.0)));
+
+// //     // Test lines through the xz plane off the origin
+// //     let plane = vec4_vec4_vec4_outer_product(
+// //         math::vec4(1.0, 10.0, 0.0, 1.0),
+// //         math::vec4(0.0, 10.0, 1.0, 1.0),
+// //         math::vec4(0.0, 10.0, 0.0, 1.0),
+// //     );
+// //     let intersection = trivec4_bivec4_meet(plane, vec4_vec4_outer_product(
+// //         math::vec4(2.0, 0.0, 3.0, 1.0),
+// //         math::vec4(2.0, 1.0, 3.0, 1.0),
+// //     ));
+// //     std::assert(math::vec4_eq(intersection, math::vec4(2.0, 10.0, 3.0, 1.0)));
+
+// //     // Test lines through the yz plane at the origin
+// //     let plane = vec4_vec4_vec4_outer_product(
+// //         math::vec4(0.0, 1.0, 0.0, 1.0),
+// //         math::vec4(0.0, 0.0, 1.0, 1.0),
+// //         math::vec4(0.0, 0.0, 0.0, 1.0),
+// //     );
+
+// //     let intersection = trivec4_bivec4_meet(plane, vec4_vec4_outer_product(
+// //         math::vec4(0.0, 0.0, 0.0, 1.0),
+// //         math::vec4(1.0, 0.0, 0.0, 1.0),
+// //     ));
+// //     std::assert(math::vec4_eq(intersection, math::vec4(0.0, 0.0, 0.0, -1.0)));
+
+// //     let intersection = trivec4_bivec4_meet(plane, vec4_vec4_outer_product(
+// //         math::vec4(1.0, 0.0, 0.0, 1.0),
+// //         math::vec4(0.0, 0.0, 0.0, 1.0),
+// //     ));
+// //     std::assert(math::vec4_eq(intersection, math::vec4(0.0, 0.0, 0.0, 1.0)));
+
+// //     let intersection = trivec4_bivec4_meet(plane, vec4_vec4_outer_product(
+// //         math::vec4(0.0, 2.0, 3.0, 1.0),
+// //         math::vec4(1.0, 2.0, 3.0, 1.0),
+// //     ));
+// //     std::assert(math::vec4_eq(intersection, math::vec4(0.0, -2.0, -3.0, -1.0)));
+
+// //     // Test lines through the yz plane off the origin
+// //     let plane = vec4_vec4_vec4_outer_product(
+// //         math::vec4(15.0, 1.0, 0.0, 1.0),
+// //         math::vec4(15.0, 0.0, 1.0, 1.0),
+// //         math::vec4(15.0, 0.0, 0.0, 1.0),
+// //     );
+// //     let intersection = trivec4_bivec4_meet(plane, vec4_vec4_outer_product(
+// //         math::vec4(0.0, 2.0, 3.0, 1.0),
+// //         math::vec4(1.0, 2.0, 3.0, 1.0),
+// //     ));
+// //     std::assert(math::vec4_eq(intersection, math::vec4(-15.0, -2.0, -3.0, -1.0)));
+
+// //     // Test a plane that doesn't line up with the axis
+// //     let plane = vec4_vec4_vec4_outer_product(
+// //         math::vec4(1.0, 0.0, 0.0, 1.0),
+// //         math::vec4(0.0, 1.0, 0.0, 1.0),
+// //         math::vec4(0.0, 0.0, 1.0, 1.0),
+// //     );
+
+// //     let intersection = trivec4_bivec4_meet(plane, vec4_vec4_outer_product(
+// //         math::vec4(0.0, 0.0, 0.0, 1.0),
+// //         math::vec4(1.0, 0.0, 0.0, 1.0),
+// //     ));
+// //     std::assert(math::vec4_eq(intersection, math::vec4(-1.0, 0.0, 0.0, -1.0)));
+
+// //     let intersection = trivec4_bivec4_meet(plane, vec4_vec4_outer_product(
+// //         math::vec4(0.0, 0.0, 0.0, 1.0),
+// //         math::vec4(0.0, 1.0, 0.0, 1.0),
+// //     ));
+// //     std::assert(math::vec4_eq(intersection, math::vec4(0.0, -1.0, 0.0, -1.0)));
+
+// //     let intersection = trivec4_bivec4_meet(plane, vec4_vec4_outer_product(
+// //         math::vec4(0.0, 0.0, 0.0, 1.0),
+// //         math::vec4(0.0, 0.0, 1.0, 1.0),
+// //     ));
+// //     std::assert(math::vec4_eq(intersection, math::vec4(0.0, 0.0, -1.0, -1.0)));
+
+// //     let intersection = trivec4_bivec4_meet(plane, vec4_vec4_outer_product(
+// //         math::vec4(0.0, 0.0, 0.0, 1.0),
+// //         math::vec4(1.0, 1.0, 1.0, 1.0),
+// //     ));
+// //     std::assert(math::vec4_eq(intersection, math::vec4(-1.0, -1.0, -1.0, -3.0)));
+
+// //     // Test the last case again, but with non-normalized inputs
+// //     let plane = vec4_vec4_vec4_outer_product(
+// //         math::vec4(1.0, 0.0, 0.0, 1.0),
+// //         math::vec4(0.0, 2.0, 0.0, 2.0),
+// //         math::vec4(0.0, 0.0, -3.0, -3.0),
+// //     );
+
+// //     let intersection = trivec4_bivec4_meet(plane, vec4_vec4_outer_product(
+// //         math::vec4(0.0, 0.0, 0.0, -1.0),
+// //         math::vec4(2.0, 0.0, 0.0, 2.0),
+// //     ));
+// //     std::assert(math::vec4_eq(intersection, math::vec4(-12.0, 0.0, 0.0, -12.0)));
+
+// //     let intersection = trivec4_bivec4_meet(plane, vec4_vec4_outer_product(
+// //         math::vec4(0.0, 0.0, 0.0, 1.0),
+// //         math::vec4(0.0, -2.0, 0.0, -2.0),
+// //     ));
+// //     std::assert(math::vec4_eq(intersection, math::vec4(0.0, -12.0, 0.0, -12.0)));
+
+// //     let intersection = trivec4_bivec4_meet(plane, vec4_vec4_outer_product(
+// //         math::vec4(0.0, 0.0, 0.0, 3.0),
+// //         math::vec4(0.0, 0.0, 3.0, 3.0),
+// //     ));
+// //     std::assert(math::vec4_eq(intersection, math::vec4(0.0, 0.0, 54.0, 54.0)));
+
+// //     let intersection = trivec4_bivec4_meet(plane, vec4_vec4_outer_product(
+// //         math::vec4(0.0, 0.0, 0.0, 1.0),
+// //         math::vec4(2.0, 2.0, 2.0, -2.0),
+// //     ));
+// //     std::assert(math::vec4_eq(intersection, math::vec4(12.0, 12.0, 12.0, 36.0)));
+
+// //     // Test trying to get the intersection when none exists
+// //     let plane = vec4_vec4_vec4_outer_product(
+// //         math::vec4(1.0, 0.0, 0.0, 1.0),
+// //         math::vec4(0.0, 1.0, 0.0, 1.0),
+// //         math::vec4(0.0, 0.0, 0.0, 1.0),
+// //     );
+// //     let intersection = trivec4_bivec4_meet(plane, vec4_vec4_outer_product(
+// //         math::vec4(0.0, 0.0, 1.0, 1.0),
+// //         math::vec4(1.0, 0.0, 1.0, 1.0),
+// //     ));
+// //     std::assert(math::vec4_eq(intersection, math::vec4(1.0, 0.0, 0.0, 0.0)));
+// //     let intersection = trivec4_bivec4_meet(plane, vec4_vec4_outer_product(
+// //         math::vec4(0.0, 0.0, 1.0, 1.0),
+// //         math::vec4(0.0, 1.0, 1.0, 1.0),
+// //     ));
+// //     std::assert(math::vec4_eq(intersection, math::vec4(0.0, 1.0, 0.0, 0.0)));
+// // }

--- a/src/vec2.zig
+++ b/src/vec2.zig
@@ -446,22 +446,6 @@ pub const Vec2 = extern struct {
         try std.testing.expectEqual(Rotor2{ .yx = -1.0, .a = 1.0 }, a.geomProd(b));
     }
 
-    /// Returns the normal to the vector CW from the input. Assumes the vector is already
-    /// normalized. If the vector is `.zero`, it is returned unchanged.
-    pub fn normal(self: Vec2) Vec2 {
-        return .{
-            .x = self.y,
-            .y = -self.x,
-        };
-    }
-
-    test normal {
-        var a: Vec2 = .{ .x = 1, .y = 2 };
-        a = a.normal();
-        try std.testing.expectEqual(Vec2{ .x = 2, .y = -1 }, a);
-        try std.testing.expectEqual(Vec2.zero, Vec2.normal(.zero));
-    }
-
     /// Returns the equivalent homogeneous point.
     pub fn point(self: Vec2) Vec3 {
         return .{ .x = self.x, .y = self.y, .z = 1.0 };
@@ -562,5 +546,24 @@ pub const Vec2 = extern struct {
             5,
             (Vec2{ .x = 10, .y = 2 }).toCartesian(),
         );
+    }
+
+    /// Returns self multiplied by yx, results in the normal vector with a magnitude the
+    /// magnitude of the input vector.
+    pub fn dual(self: Vec2) Vec2 {
+        return .{
+            .x = -self.y,
+            .y = self.x,
+        };
+    }
+
+    test dual {
+        const a: Vec2 = .{
+            .x = 1,
+            .y = 2,
+        };
+        try std.testing.expectEqual(Vec2{ .x = -2, .y = 1 }, a.dual());
+        try std.testing.expectEqual(a, a.dual().dual().dual().dual());
+        try std.testing.expectEqual(a.negated(), a.dual().dual());
     }
 };

--- a/src/vec3.zig
+++ b/src/vec3.zig
@@ -591,4 +591,25 @@ pub const Vec3 = extern struct {
             (Vec3{ .x = 10, .y = 20, .z = 2 }).toCartesian(),
         );
     }
+
+    /// Returns self multiplied by zyx, results in the orthogonal bivector with an area of the
+    /// magnitude of this vector.
+    pub fn dual(self: Vec3) Bivec3 {
+        return .{
+            .yz = -self.x,
+            .xz = self.y,
+            .yx = self.z,
+        };
+    }
+
+    test dual {
+        const a: Vec3 = .{
+            .x = 1,
+            .y = 2,
+            .z = 3,
+        };
+        try std.testing.expectEqual(Bivec3{ .yz = -1, .xz = 2, .yx = 3 }, a.dual());
+        try std.testing.expectEqual(a, a.dual().dual().dual().dual());
+        try std.testing.expectEqual(a.negated(), a.dual().dual());
+    }
 };


### PR DESCRIPTION
Started implemented more types and operations so that I could port WoR's unproject onto plane functionality. This can be useful if the camera rotates due to shake, or for neat styles where the camera is at an angle.

However, I realized that it's not really important for what I'm doing right now, and I really want to understand the math better to make sure I'm getting it right. I was able to verify some of it with [GAViewer](https://geometricalgebra.org/gaviewer_download.html), but I don't really understand duals. (They seem straight forward, but my results don't match GA viewer... Maybe I'm getting the algebra wrong when reordering basis multiplied in groups of four?)

I should probably pick up a copy of either or both of these:
* https://www.amazon.com/Projective-Geometric-Algebra-Illuminated-Lengyel-ebook/dp/B0F7FZLNVD
* https://www.amazon.com/dp/0985811749/

Additionally, Eric (author of the above two books) also has a lot of info here:
* http://projectivegeometricalgebra.org/
* https://rigidgeometricalgebra.org/wiki/index.php?title=Main_Page
* https://conformalgeometricalgebra.org/wiki/index.php?title=Main_Page

And check out this talk:
* https://gdcvault.com/browse?keyword=geometric+algebra